### PR TITLE
[Feat] 온보딩UI

### DIFF
--- a/Spender/app/build.gradle.kts
+++ b/Spender/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.kotlin.dsl.implementation
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -66,5 +68,7 @@ dependencies {
 
     implementation(libs.mpandroidchart)
     implementation(libs.androidx.material.icons.extended)
+
+    implementation("androidx.datastore:datastore-preferences:1.1.7")
 
 }

--- a/Spender/app/src/main/java/com/example/spender/MainActivity.kt
+++ b/Spender/app/src/main/java/com/example/spender/MainActivity.kt
@@ -25,9 +25,11 @@ import com.example.spender.core.ui.BottomNavigationBar
 import com.example.spender.feature.analysis.AnalysisScreen
 import com.example.spender.feature.home.HomeScreen
 import com.example.spender.feature.mypage.MypageScreen
+import com.example.spender.feature.onboarding.data.OnboardingPref
 import com.example.spender.feature.report.ui.list.ReportListScreen
 import com.example.spender.ui.theme.SpenderTheme
 import com.example.spender.ui.theme.navigation.BottomNavigationItem
+import com.example.spender.ui.theme.navigation.Screen
 import com.example.spender.ui.theme.navigation.SpenderNavigation
 
 class MainActivity : ComponentActivity() {
@@ -40,7 +42,18 @@ class MainActivity : ComponentActivity() {
                 dynamicColor = false
             ) {
                 val navController = rememberNavController()
-                SpenderNavigation(navController)
+
+                val isOnboardingShown = OnboardingPref.wasShown(this)
+                val startDestination = if (isOnboardingShown) {
+                    Screen.MainScreen.route
+                } else {
+                    Screen.OnboardingScreen.route
+                }
+
+                SpenderNavigation(
+                    navController = navController,
+                    startDestination = startDestination
+                )
             }
         }
     }

--- a/Spender/app/src/main/java/com/example/spender/core/common/util/CurrencyVisualTransformation.kt
+++ b/Spender/app/src/main/java/com/example/spender/core/common/util/CurrencyVisualTransformation.kt
@@ -1,0 +1,44 @@
+package com.example.spender.core.common.util
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+class CurrencyVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val rawText = text.text.filter { it.isDigit() }
+
+        if (rawText.isEmpty()) {
+            return TransformedText(
+                AnnotatedString(""),
+                OffsetMapping.Identity
+            )
+        }
+
+        val number = rawText.toLongOrNull() ?: 0L
+        val formatted = "%,d".format(number)
+
+        val offsetMapping = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                if (offset <= 0) return 0
+                if (offset >= rawText.length) return formatted.length
+
+                val beforeOffset = rawText.substring(0, offset)
+                val transformedBefore = "%,d".format(beforeOffset.toLongOrNull() ?: 0L)
+                return transformedBefore.length
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                val digitsBeforeOffset = formatted.substring(0, offset.coerceAtMost(formatted.length))
+                    .filter { it.isDigit() }
+                return digitsBeforeOffset.length
+            }
+        }
+
+        return TransformedText(
+            AnnotatedString(formatted),
+            offsetMapping
+        )
+    }
+}

--- a/Spender/app/src/main/java/com/example/spender/core/ui/CustomButton.kt
+++ b/Spender/app/src/main/java/com/example/spender/core/ui/CustomButton.kt
@@ -24,6 +24,7 @@ import com.example.spender.ui.theme.WhiteColor
 fun CustomLongButton(
     text: String,
     onClick: () -> Unit,
+    isEnabled: Boolean = true,
     modifier: Modifier = Modifier
         .height(56.dp)
         .fillMaxWidth()
@@ -32,10 +33,11 @@ fun CustomLongButton(
         onClick = onClick,
         modifier = modifier,
         colors = ButtonDefaults.buttonColors(
-            containerColor = PointColor,
+            containerColor = if (isEnabled) PointColor else LightPointColor,
             contentColor = WhiteColor
         ),
         shape = RoundedCornerShape(16.dp),
+        enabled = isEnabled
     ) {
         Text(
             text = text,

--- a/Spender/app/src/main/java/com/example/spender/feature/onboarding/OnboardingScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/onboarding/OnboardingScreen.kt
@@ -1,0 +1,88 @@
+package com.example.spender.feature.onboarding
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.spender.feature.onboarding.ui.OnboardingViewModel
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.example.spender.R
+import com.example.spender.core.ui.CustomLongButton
+import com.example.spender.feature.onboarding.data.OnboardingPref
+import com.example.spender.feature.onboarding.ui.BudgetInputField
+import com.example.spender.feature.onboarding.ui.PageIndicator
+import com.example.spender.ui.theme.Typography
+import com.example.spender.ui.theme.navigation.Screen
+
+@Composable
+fun OnboardingScreen(
+    navController: NavHostController,
+    viewModel: OnboardingViewModel = viewModel()
+) {
+    val context = LocalContext.current
+
+    val currentPage by viewModel.currentPage.collectAsState()
+    val budget by viewModel.budget.collectAsState()
+    val isBudgetValid = viewModel.isBudgetValid
+
+    val titles = context.resources.getStringArray(R.array.onboarding_title).toList()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp, vertical = 32.dp),
+        verticalArrangement = Arrangement.SpaceBetween
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            PageIndicator(currentPage = currentPage, pageCount = titles.size)
+
+            Text(
+                text = titles[currentPage],
+                style = Typography.titleLarge,
+                textAlign = TextAlign.Center
+            )
+
+            if (currentPage == 1) {
+                Spacer(modifier = Modifier.height(80.dp))
+                BudgetInputField(
+                    budget = budget,
+                    onBudgetChange = { viewModel.onBudgetGet(it) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                )
+            }
+        }
+
+        CustomLongButton(
+            text = if (currentPage < 2) "다음" else "시작하기",
+            onClick = {
+                if (currentPage < 2) {
+                    viewModel.onNext()
+                } else {
+                    OnboardingPref.setShown(context)
+                    navController.navigate(Screen.MainScreen.route) {
+                        popUpTo(Screen.OnboardingScreen.route) {
+                            inclusive = true
+                        }
+                    }
+                }
+            },
+            isEnabled = currentPage != 1 || isBudgetValid
+        )
+    }
+}

--- a/Spender/app/src/main/java/com/example/spender/feature/onboarding/data/OnboardingPref.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/onboarding/data/OnboardingPref.kt
@@ -1,0 +1,18 @@
+package com.example.spender.feature.onboarding.data
+
+import android.content.Context
+
+object OnboardingPref {
+    private const val PREF_NAME = "onboarding_prefs"
+    private const val KEY_SHOWN = "onboarding_shown"
+
+    fun setShown(context: Context) {
+        val pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        pref.edit().putBoolean(KEY_SHOWN, true).apply()
+    }
+
+    fun wasShown(context: Context): Boolean {
+        val pref = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return pref.getBoolean(KEY_SHOWN, false)
+    }
+}

--- a/Spender/app/src/main/java/com/example/spender/feature/onboarding/ui/BudgetInputField.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/onboarding/ui/BudgetInputField.kt
@@ -1,0 +1,63 @@
+package com.example.spender.feature.onboarding.ui
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.example.spender.core.common.util.CurrencyVisualTransformation
+import com.example.spender.ui.theme.LightSurface
+import com.example.spender.ui.theme.TabColor
+import com.example.spender.ui.theme.Typography
+
+@Composable
+fun BudgetInputField(
+    budget: Int,
+    onBudgetChange: (Int) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+    ) {
+        TextField(
+            value = budget?.takeIf { it != 0 }?.toString() ?: "",
+            onValueChange = { input ->
+                val numbersOnly = input.filter { it.isDigit() }
+                val intBudget = numbersOnly.toIntOrNull() ?: 0
+                onBudgetChange(intBudget)
+            },
+            colors = TextFieldDefaults.colors(
+                focusedContainerColor = LightSurface,
+                unfocusedContainerColor = LightSurface,
+                focusedIndicatorColor = TabColor,
+                unfocusedIndicatorColor = TabColor,
+                cursorColor = TabColor,
+            ),
+            textStyle = Typography.titleLarge,
+            placeholder = {
+                Text(
+                    "예산을 입력해주세요",
+                    style = Typography.titleLarge.copy(
+                        color = TabColor
+                    )
+                )
+            },
+            visualTransformation = CurrencyVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.weight(1f)
+        )
+        Spacer(Modifier.width(8.dp))
+        Text(
+            "원",
+            style = Typography.titleLarge
+        )
+    }
+}

--- a/Spender/app/src/main/java/com/example/spender/feature/onboarding/ui/OnboardingViewModel.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/onboarding/ui/OnboardingViewModel.kt
@@ -1,0 +1,27 @@
+package com.example.spender.feature.onboarding.ui
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class OnboardingViewModel : ViewModel() {
+    private val _currentPage = MutableStateFlow(0)
+    val currentPage: StateFlow<Int> = _currentPage.asStateFlow()
+
+    private val _budget = MutableStateFlow(0)
+    val budget: StateFlow<Int> = _budget.asStateFlow()
+
+    fun onNext() {
+        _currentPage.value += 1
+    }
+
+    fun onBudgetGet(budget: Int) {
+        _budget.value = budget
+        Log.d("Budget", "onBudgetGet: ${_budget.value}")
+    }
+
+    val isBudgetValid: Boolean
+        get() = _budget.value > 0
+}

--- a/Spender/app/src/main/java/com/example/spender/feature/onboarding/ui/PageIndicator.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/onboarding/ui/PageIndicator.kt
@@ -1,0 +1,37 @@
+package com.example.spender.feature.onboarding.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.spender.ui.theme.LightPointColor
+import com.example.spender.ui.theme.PointColor
+
+@Composable
+fun PageIndicator(currentPage: Int, pageCount: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        horizontalArrangement = Arrangement.Center
+    ) {
+        repeat(pageCount) { index ->
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(4.dp)
+                    .background(
+                        color = if (index == currentPage) PointColor else LightPointColor,
+                        shape = CircleShape
+                    )
+            )
+        }
+    }
+}

--- a/Spender/app/src/main/java/com/example/spender/ui/theme/navigation/Navigation.kt
+++ b/Spender/app/src/main/java/com/example/spender/ui/theme/navigation/Navigation.kt
@@ -8,17 +8,24 @@ import com.example.spender.MainScreen
 import com.example.spender.feature.analysis.AnalysisScreen
 import com.example.spender.feature.home.HomeScreen
 import com.example.spender.feature.mypage.MypageScreen
+import com.example.spender.feature.onboarding.OnboardingScreen
 import com.example.spender.feature.report.ui.detail.ReportDetailScreen
 import com.example.spender.feature.report.ui.list.ReportListScreen
 
 @Composable
-fun SpenderNavigation(navController: NavHostController) {
+fun SpenderNavigation(
+    navController: NavHostController,
+    startDestination: String
+) {
     NavHost(
         navController = navController,
-        startDestination = Screen.MainScreen.route
+        startDestination = startDestination
     ) {
         composable(Screen.MainScreen.route) {
             MainScreen(navController)
+        }
+        composable(Screen.OnboardingScreen.route) {
+            OnboardingScreen(navController)
         }
         composable(BottomNavigationItem.Home.route) {
             HomeScreen(navController)
@@ -33,9 +40,9 @@ fun SpenderNavigation(navController: NavHostController) {
             MypageScreen(navController)
         }
 
-        composable(Screen.ReportDetail.route){ backStackEntry ->
+        composable(Screen.ReportDetail.route) { backStackEntry ->
             val reportId = backStackEntry.arguments?.getString("reportId")?.toIntOrNull()
-            if(reportId != null){
+            if (reportId != null) {
                 ReportDetailScreen(navController, reportId)
             }
         }

--- a/Spender/app/src/main/java/com/example/spender/ui/theme/navigation/Screen.kt
+++ b/Spender/app/src/main/java/com/example/spender/ui/theme/navigation/Screen.kt
@@ -2,8 +2,9 @@ package com.example.spender.ui.theme.navigation
 
 sealed class Screen(val route: String) {
     object MainScreen : Screen("main")
+    object OnboardingScreen : Screen("onboarding")
 
-    object ReportDetail: Screen("report_detail/{reportId}"){
+    object ReportDetail : Screen("report_detail/{reportId}") {
         fun createRoute(reportId: Int) = "report_detail/$reportId"
     }
 }

--- a/Spender/app/src/main/res/values/strings.xml
+++ b/Spender/app/src/main/res/values/strings.xml
@@ -4,4 +4,10 @@
     <string name="tab_analysis">통계</string>
     <string name="tab_mypage">마이페이지</string>
     <string name="tab_report">리포트</string>
+
+    <string-array name="onboarding_title">
+        <item>우리앱자랑을여기에써야하는데뭘써야할지모르겠네요</item>
+        <item>한달 예산은 얼마인가요?</item>
+        <item>이제 시작해봅시다.</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## 변경 내용 요약
- 온보딩 UI가 완성되었습니다.(어플 소개 문구는 추후 개선 필요)
- Navigation과 MainActivity쪽 수정이 있습니다 : 홈화면과 온보딩 화면 2가지로 분기하여 앱 최초 실행시 온보딩이 나오도록 설정
- TextField visualTransformation에 넣을 수 있는 확장함수(금액 입력할 때 천 단위마다 ,가 붙는)를 구현하였습니다
- LongButton 인자에 isEnabled(기본값 true)가 추가되었습니다

우다다 하다보니 commit이 하나밖에 없어서 보기 힘들...겁니다 이 점에 대해선 죄송하게 생각합니다^_ㅠ

## UI 스크릿샷 or 기능 테스트 방법
https://github.com/user-attachments/assets/ab21b5fc-0696-484f-bcfd-2ff8860f0848

## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
