### PR TITLE
[Fix] 말풍선이 바 따라가도록 수정

### DIFF
--- a/Spender/app/src/main/java/com/example/spender/feature/home/HomeScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/HomeScreen.kt
@@ -57,7 +57,8 @@ fun HomeScreen(navHostController: NavHostController) {
             LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding),
+                    .padding(padding)
+                    .padding(horizontal = 5.dp),
             ) {
                 item {
                     TotalExpenseCard(totalExpense = totalExpense)

--- a/Spender/app/src/main/java/com/example/spender/feature/home/ui/BudgetProgressBar.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/ui/BudgetProgressBar.kt
@@ -2,8 +2,11 @@ package com.example.spender.feature.home.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -14,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.example.spender.ui.theme.LightSurface
 import com.example.spender.ui.theme.PointColor
 
@@ -31,29 +35,51 @@ fun BudgetProgressBar(
             containerColor = LightSurface
         ),
     ) {
-        //TODO : 텍스트말풍선이 프로그래스 바를 쫓아가게 수정할 것
-        BubbleWithText(percentText)
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .height(16.dp),
-            contentAlignment = Alignment.CenterStart
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth().padding(top = 40.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(16.dp)
-                    .clip(RoundedCornerShape(100))
-                    .background(Color(0xFFF0F0F0))
-            )
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth(percentage.coerceIn(0f, 1f))
-                    .height(16.dp)
-                    .clip(RoundedCornerShape(100))
-                    .background(PointColor)
-            )
+            val barWidth = maxWidth
+            val bubbleOffset = (barWidth * percentage.coerceIn(0f, 1f)) - 24.dp
+
+            Box {
+                // 말풍선
+                Box(
+                    modifier = Modifier
+                        .offset(
+                            x = bubbleOffset.coerceIn(0.dp, barWidth - 48.dp),
+                            y = (-32).dp
+                        )
+                        .zIndex(1f) // 말풍선이 위에 오도록
+                ) {
+                    BubbleWithText(percentText)
+                }
+
+                // 프로그래스 바
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(16.dp)
+                        .align(Alignment.CenterStart),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(16.dp)
+                            .clip(RoundedCornerShape(100))
+                            .background(Color(0xFFF0F0F0))
+                    )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth(percentage.coerceIn(0f, 1f))
+                            .height(16.dp)
+                            .clip(RoundedCornerShape(100))
+                            .background(PointColor)
+                    )
+                }
+            }
+
+
         }
     }
 }


### PR DESCRIPTION
## 변경 내용 요약
- 말풍선이 바 따라가도록 수정했습니다~! 
- 홈에 가로 패딩 약간 더 줬습니다~! 

## UI 스크릿샷 or 기능 테스트 방법
<img width="1080" height="2220" alt="Image" src="https://github.com/user-attachments/assets/9b91613a-e312-4678-879e-73e9288856a3" />

## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
