### PR TITLE
[Feat] 홈에서 예산설정

### DIFF
--- a/Spender/app/src/main/java/com/example/spender/feature/home/HomeScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/HomeScreen.kt
@@ -63,7 +63,11 @@ fun HomeScreen(navHostController: NavHostController) {
                     TotalExpenseCard(totalExpense = totalExpense)
                 }
                 item {
-                    BudgeProgress(budget = budget, totalExpense = totalExpense)
+                    BudgeProgress(
+                        budget = budget,
+                        totalExpense = totalExpense,
+                        navHostController = navHostController
+                    )
                 }
                 item {
                     RecentTransactionsSection() // TODO: 각 데이터의 필드(수입,지출 제목 & 금액) 넘겨줘야 함

--- a/Spender/app/src/main/java/com/example/spender/feature/home/ui/BudgetProgressSection.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/ui/BudgetProgressSection.kt
@@ -21,13 +21,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import com.example.spender.R
 import com.example.spender.ui.theme.LightSurface
 import com.example.spender.ui.theme.PointColor
 import com.example.spender.ui.theme.Typography
 
 @Composable
-fun BudgeProgress(budget: Int, totalExpense: Int) {
+fun BudgeProgress(
+    budget: Int,
+    totalExpense: Int,
+    navHostController: NavHostController
+) {
     val percentage = totalExpense.toFloat() / budget.toFloat()
     val percentText = "${(percentage * 100).toInt()}%"
 
@@ -97,7 +102,7 @@ fun BudgeProgress(budget: Int, totalExpense: Int) {
             TextButton(
                 modifier = Modifier,
                 onClick = {
-                    //TODO: 예산설정화면으로 이동하는 로직
+                    navHostController.navigate("budget")
                 }
             ) {
                 Text(


### PR DESCRIPTION
## 변경 내용 요약
- 홈에 있는 [예산 설정하러 가기]를 누르면 예산 설정 화면으로 이동합니다


## UI 스크릿샷 or 기능 테스트 방법
[Screen_recording_20250805_095126.webm](https://github.com/user-attachments/assets/57d9f545-e418-469d-8845-5e05b8e332ff)


## 체크 리스트
- [ ] 기능 정상 동작 확인
- [ ] 사이드 이펙트 확인
