### PR TITLE
[Fix] 카테고리설정 플로팅버튼, 다이어로그 디테일 수정

### DIFF
--- a/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/ExpenseCategoryScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/ExpenseCategoryScreen.kt
@@ -97,7 +97,8 @@ fun ExpenseCategoryScreen(navHostController: NavHostController) {
                         showEditDialog = true
                     }
                 },
-                containerColor = Color.White
+                containerColor = Color.White,
+                shape = CircleShape
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_floating_add),

--- a/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/ExpenseCategoryScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/ExpenseCategoryScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -206,7 +207,7 @@ private fun CategoryRow(
                     .background(Color.White)
                     .border(
                         width = 1.dp,
-                        color = Color.LightGray,
+                        color = Color.Gray,
                         shape = RoundedCornerShape(4.dp)
                     )
             ) {
@@ -224,9 +225,11 @@ private fun CategoryRow(
                         onEditClick()
                         expanded = false
                     },
-                    contentPadding = PaddingValues(horizontal = 42.dp, vertical = 8.dp)
+                    modifier = Modifier
+                        .height(34.dp)
+                        .width(120.dp),
                 )
-                HorizontalDivider()
+                HorizontalDivider(modifier = Modifier.padding(vertical = 6.dp), color = Color.Gray)
                 DropdownMenuItem(
                     text = {
                         Text(
@@ -241,7 +244,9 @@ private fun CategoryRow(
                         onDeleteClick()
                         expanded = false
                     },
-                    contentPadding = PaddingValues(horizontal = 42.dp, vertical = 8.dp)
+                    modifier = Modifier
+                        .height(34.dp)
+                        .width(120.dp),
                 )
             }
         }

--- a/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/IncomeCategoryScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/IncomeCategoryScreen.kt
@@ -12,6 +12,7 @@ import com.example.spender.R
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
@@ -76,7 +77,8 @@ fun IncomeCategoryScreen(navHostController: NavHostController) {
                     currentCategory = null
                     showEditDialog = true
                 },
-                containerColor = Color.White
+                containerColor = Color.White,
+                shape = CircleShape
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_floating_add),

--- a/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/IncomeCategoryScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/IncomeCategoryScreen.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import com.example.spender.R
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -170,7 +173,7 @@ private fun IncomeCategoryRow(
                     .background(Color.White)
                     .border(
                         width = 1.dp,
-                        color = Color.LightGray,
+                        color = Color.Gray,
                         shape = RoundedCornerShape(4.dp)
                     )
             ) {
@@ -188,9 +191,11 @@ private fun IncomeCategoryRow(
                         onEditClick()
                         expanded = false
                     },
-                    contentPadding = PaddingValues(horizontal = 42.dp, vertical = 8.dp)
+                    modifier = Modifier
+                        .height(34.dp)
+                        .width(120.dp),
                 )
-                HorizontalDivider()
+                HorizontalDivider(modifier = Modifier.padding(vertical = 6.dp), color = Color.Gray)
                 DropdownMenuItem(
                     text = {
                         Text(
@@ -205,7 +210,9 @@ private fun IncomeCategoryRow(
                         onDeleteClick()
                         expanded = false
                     },
-                    contentPadding = PaddingValues(horizontal = 42.dp, vertical = 8.dp)
+                    modifier = Modifier
+                        .height(34.dp)
+                        .width(120.dp),
                 )
             }
         }

--- a/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/component/CategoryDialogs.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/component/CategoryDialogs.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -33,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.example.spender.feature.mypage.domain.model.Category
 import com.example.spender.ui.theme.PointColor
@@ -73,11 +75,19 @@ fun CategoryEditDialog(
                     TextField(
                         value = text,
                         onValueChange = { text = it },
-                        label = { Text("카테고리 이름") },
+                        placeholder = {
+                            Text(
+                                "카테고리 이름을 입력해주세요",
+                                color = Color.Gray,
+                                fontSize = 14.sp
+                            )
+                        },
                         singleLine = true,
                         colors = TextFieldDefaults.colors(
                             unfocusedContainerColor = Color.Transparent,
-                            focusedContainerColor = Color.Transparent
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.LightGray,
+                            focusedIndicatorColor = PointColor
                         ),
                         textStyle = Typography.titleMedium
                     )


### PR DESCRIPTION
## 변경 내용 요약
- 카테고리설정 화면의 플로팅버튼 아이콘뒤에 버튼이 희미하게 튀어나온현상 수정
- 다이어로그 라벨 삭제, 밑줄색상 변경

## UI 스크릿샷 or 기능 테스트 방법
<img width="78" height="83" alt="image" src="https://github.com/user-attachments/assets/28e4f8db-a750-4143-9dc8-878053de6f40" />
->
<img width="80" height="86" alt="image" src="https://github.com/user-attachments/assets/536a4c85-25a7-4328-ba99-00a35f47c26d" />


## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
