### PR TITLE
feat: ExpenseDetail화면으로 이동하는 네비 추가

### DIFF
--- a/Spender/app/src/main/java/com/example/spender/core/data/remote/expense/ExpenseDto.kt
+++ b/Spender/app/src/main/java/com/example/spender/core/data/remote/expense/ExpenseDto.kt
@@ -3,6 +3,7 @@ package com.example.spender.core.data.remote.expense
 import com.google.firebase.Timestamp
 
 data class ExpenseDto(
+    val id: String = "",
     val amount: Int,
     val memo: String = "",
     val title: String,

--- a/Spender/app/src/main/java/com/example/spender/core/data/service/FirebaseMainFunctions.kt
+++ b/Spender/app/src/main/java/com/example/spender/core/data/service/FirebaseMainFunctions.kt
@@ -100,6 +100,7 @@ suspend fun getExpenseListForHome(): List<ExpenseDto> {
         for (doc in document) {
             val data = doc.data
             val expense = ExpenseDto(
+                id = doc.id,
                 amount = data["amount"].toString().toInt(),
                 title = data["title"].toString(),
                 date = data["date"] as Timestamp,

--- a/Spender/app/src/main/java/com/example/spender/feature/home/HomeScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/HomeScreen.kt
@@ -86,7 +86,10 @@ fun HomeScreen(navHostController: NavHostController) {
                     )
                 }
                 item {
-                    RecentTransactionsSection(recentExpenses = recentExpenses)
+                    RecentTransactionsSection(
+                        recentExpenses = recentExpenses,
+                        navHostController = navHostController
+                    )
                 }
             }
         }

--- a/Spender/app/src/main/java/com/example/spender/feature/home/ui/RecentTransactionSection.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/ui/RecentTransactionSection.kt
@@ -11,12 +11,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
 import com.example.spender.core.data.remote.expense.ExpenseDto
 import com.example.spender.feature.home.ui.component.RecentItem
 import com.example.spender.ui.theme.Typography
+import com.example.spender.ui.theme.navigation.Screen
 
 @Composable
-fun RecentTransactionsSection(recentExpenses: List<ExpenseDto>) {
+fun RecentTransactionsSection(
+    recentExpenses: List<ExpenseDto>,
+    navHostController: NavHostController
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -37,7 +42,12 @@ fun RecentTransactionsSection(recentExpenses: List<ExpenseDto>) {
         recentExpenses.forEach { expense ->
             RecentItem(
                 title = expense.title,
-                amount = expense.amount
+                amount = expense.amount,
+                onClick = {
+                    navHostController.navigate(
+                        Screen.ExpenseDetailScreen.createRoute(expense.id)
+                    )
+                }
             )
             Spacer(modifier = Modifier.height(8.dp))
         }

--- a/Spender/app/src/main/java/com/example/spender/feature/home/ui/component/RecentItem.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/home/ui/component/RecentItem.kt
@@ -1,5 +1,6 @@
 package com.example.spender.feature.home.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,12 +22,14 @@ import com.example.spender.ui.theme.Typography
 @Composable
 fun RecentItem(
     title: String,
-    amount: Int
+    amount: Int,
+    onClick: () -> Unit
 ) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .height(72.dp),
+            .height(72.dp)
+            .clickable { onClick() },
         shape = RoundedCornerShape(10.dp),
         colors = CardDefaults.cardColors(
             containerColor = LightSurface,


### PR DESCRIPTION
## 변경 내용 요약
- expenseId..가 없어서 대신 DocId를 받아오게끔 하였고 이로 인해 Dto에 필드가 하나 추가되었습니다
- 홈화면에서 최근기록 하나 누르면 Detail화면으로 넘어가게 하였습니다

## UI 스크릿샷 or 기능 테스트 방법


## 체크 리스트
- [ ] 기능 정상 동작 확인
- [ ] 사이드 이펙트 확인
