### PR TITLE
[Feat] 지출 리포트 연도 선택 다이얼로그 추가

### DIFF
--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/ReportContent.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/ReportContent.kt
@@ -55,7 +55,7 @@ fun ReportContent(
         modifier = Modifier
             .fillMaxSize()
             .padding(paddingValues)
-            .padding(top = 40.dp)
+            .padding(top = 0.dp)
             .background(color = LightBackgroundColor)
     ) {
         MonthlySpendingBarChart(

--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/ReportTopAppBar.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/ReportTopAppBar.kt
@@ -1,5 +1,6 @@
 package com.example.spender.feature.report.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,12 +17,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import java.util.Calendar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ReportTopAppBar(year: Int, onPrev: () -> Unit, onNext: () -> Unit) {
+fun ReportTopAppBar(year: Int, onPrev: () -> Unit, onNext: () -> Unit, onYearClick: () -> Unit) {
     val currentYear = Calendar.getInstance().get(Calendar.YEAR)
 
     CenterAlignedTopAppBar(
@@ -38,7 +40,8 @@ fun ReportTopAppBar(year: Int, onPrev: () -> Unit, onNext: () -> Unit) {
 
                 Text(
                     text = "${year}년",
-                    modifier = Modifier.padding(horizontal = 8.dp)
+                    modifier = Modifier.padding(horizontal = 8.dp).clickable{ onYearClick() },
+                    textDecoration = TextDecoration.Underline
                 )
 
                 IconButton(

--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/YearPickerDialog.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/YearPickerDialog.kt
@@ -1,0 +1,84 @@
+package com.example.spender.feature.report.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.example.spender.ui.theme.PointColor
+import com.example.spender.ui.theme.Typography
+
+@Composable
+fun YearPickerDialog(
+    currentYear: Int,
+    selectedYear: Int,
+    onYearSelected: (Int) -> Unit,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = Color.White
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(16.dp)
+            ) {
+                Text(
+                    text = "연도 선택",
+                    style = Typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+
+                val yearList = (currentYear downTo currentYear - 3).toList()
+                var tempYear by remember { mutableIntStateOf(selectedYear) }
+
+                LazyColumn(
+                    modifier = Modifier
+                        .height(200.dp)
+                        .padding(vertical = 8.dp)
+                ) {
+                    items(yearList) { year ->
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    tempYear = year
+                                    onYearSelected(year)
+                                    onDismiss()
+                                }
+                                .padding(12.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "$year 년",
+                                style = Typography.bodyLarge.copy(
+                                    fontWeight = if (year == tempYear) FontWeight.Bold else FontWeight.Normal
+                                ),
+                                color = if (year == tempYear) PointColor else Color.Black
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/list/ReportListScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/list/ReportListScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -17,6 +18,7 @@ import com.example.spender.core.ui.LoadingScreen
 import com.example.spender.feature.report.ui.component.EmptyReport
 import com.example.spender.feature.report.ui.component.ReportContent
 import com.example.spender.feature.report.ui.component.ReportTopAppBar
+import com.example.spender.feature.report.ui.component.YearPickerDialog
 import com.github.mikephil.charting.animation.ChartAnimator
 import com.github.mikephil.charting.charts.BarChart
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
@@ -36,8 +38,10 @@ fun ReportListScreen(
     val barValues = reports.map { it.totalExpense.toFloat() }
     val barLabels = reports.map { it.month.substring(5) + "월" }
 
+    var showYearDialog by remember { mutableStateOf(false) }
+
     val listState = rememberLazyListState()
-    var selectedIndex by remember { mutableStateOf(-1) }
+    var selectedIndex by remember { mutableIntStateOf(-1) }
 
     LaunchedEffect(selectedIndex) {
         if (selectedIndex >= 0) listState.animateScrollToItem(selectedIndex)
@@ -54,7 +58,7 @@ fun ReportListScreen(
         topBar = {
             ReportTopAppBar(year = year, onPrev = viewModel::goToPreviousYear, onNext = {
                 if (year < currentYear) viewModel.goToNextYear()
-            })
+            }, onYearClick = { showYearDialog = true })
         },
         content = { padding ->
             when{
@@ -79,6 +83,18 @@ fun ReportListScreen(
             }
         }
     )
+
+    if (showYearDialog) {
+        YearPickerDialog(
+            currentYear = currentYear,
+            selectedYear = year,
+            onYearSelected = {
+                viewModel.setYear(it)
+                showYearDialog = false
+            },
+            onDismiss = { showYearDialog = false }
+        )
+    }
 }
 
 // 막대 그래프 둥글게 처리

--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/list/ReportListViewModel.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/list/ReportListViewModel.kt
@@ -65,4 +65,8 @@ class ReportListViewModel @Inject constructor(
     fun goToNextYear() {
         loadReports(_currentYear.value + 1)
     }
+
+    fun setYear(year: Int){
+        loadReports(year)
+    }
 }


### PR DESCRIPTION
## 변경 내용 요약
- 연도 선택할 수 있도록 다이얼로그 추가했습니다~!

## UI 스크릿샷 or 기능 테스트 방법
<img width="1080" height="2220" alt="Image" src="https://github.com/user-attachments/assets/964c20fe-6e59-4da5-bede-1b1e1e37f48d" />

## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
