### PR TITLE
[Fix] 다크모드에서 색이 제대로 안바뀌던 문제 해결

### DIFF
--- a/Spender/app/src/main/java/com/example/spender/feature/analysis/AnalysisScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/analysis/AnalysisScreen.kt
@@ -1,24 +1,19 @@
 package com.example.spender.feature.analysis
 
-import androidx.compose.animation.core.animateDp
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,27 +22,70 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.navigation.NavHostController
 import com.example.spender.feature.analysis.ui.calendar.CalendarScreen
 import com.example.spender.feature.analysis.ui.graph.GraphScreen
 import com.example.spender.ui.theme.SpenderTheme
+import com.example.spender.ui.theme.Typography
 
 @Composable
 fun AnalysisScreen(navHostController: NavHostController) {
     var selectedTabIndex by remember { mutableStateOf(0) }
-    val tabTitles = listOf("캘린더", "그래프")
+    val tabs = listOf("캘린더", "그래프")
 
     Column(modifier = Modifier.fillMaxSize()) {
-        TabSelector(
-            tabs = tabTitles,
+        Spacer(modifier = Modifier.height(20.dp))
+
+        // 탭 메뉴
+        TabRow(
             selectedTabIndex = selectedTabIndex,
-            onTabSelected = { selectedTabIndex = it })
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .height(56.dp)
+                .clip(RoundedCornerShape(8.dp)),
+            containerColor = MaterialTheme.colorScheme.tertiary,
+            indicator = { tabPositions ->
+                Box(
+                    modifier = Modifier
+                        .tabIndicatorOffset(tabPositions[selectedTabIndex])
+                        .fillMaxSize()
+                        .padding(4.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.background,
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                )
+            },
+            divider = {}
+        ) {
+            tabs.forEachIndexed { index, title ->
+                val isSelected = selectedTabIndex == index
+                Box(
+                    modifier = Modifier
+                        .height(52.dp)
+                        .fillMaxHeight()
+                        .zIndex(1f)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { selectedTabIndex = index }
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = title,
+                        style = Typography.titleMedium,
+                        color = if (isSelected) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.onTertiary,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            }
+        }
 
         Spacer(modifier = Modifier.height(30.dp))
 
@@ -55,82 +93,6 @@ fun AnalysisScreen(navHostController: NavHostController) {
     }
 }
 
-@Composable
-fun TabSelector(
-    tabs: List<String>,
-    selectedTabIndex: Int,
-    onTabSelected: (Int) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Spacer(modifier = Modifier.height(20.dp))
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp)
-                .background(
-                    color = MaterialTheme.colorScheme.tertiary,
-                    shape = RoundedCornerShape(8.dp)
-                )
-        ) {
-            val transition =
-                updateTransition(targetState = selectedTabIndex, label = "tab_transition")
-            val indicatorOffset by transition.animateDp(
-                transitionSpec = { tween(250) },
-                label = "indicator_offset"
-            ) {
-                val fullWidth = LocalConfiguration.current.screenWidthDp.dp - 24.dp * 2
-                (fullWidth / 2) * it
-            }
-
-            val indicatorWidth = with(LocalDensity.current) {
-                ((LocalConfiguration.current.screenWidthDp.dp - 24.dp * 2 - 4.dp) / 2)
-            }
-
-            Box(
-                modifier = Modifier
-                    .offset(x = indicatorOffset)
-                    .width(indicatorWidth)
-                    .height(43.dp)
-                    .padding(2.dp)
-                    .background(
-                        color = MaterialTheme.colorScheme.background,
-                        shape = RoundedCornerShape(8.dp)
-                    )
-            )
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(44.dp),
-                horizontalArrangement = Arrangement.SpaceEvenly
-            ) {
-                tabs.forEachIndexed { index, title ->
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .clickable(
-                                indication = null,
-                                interactionSource = interactionSource
-                            ) { onTabSelected(index) }
-                            .padding(vertical = 8.dp),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Text(
-                            text = title,
-                            color = if (selectedTabIndex == index) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.onTertiary,
-                            style = MaterialTheme.typography.bodyMedium,
-                            textAlign = TextAlign.Center,
-                            modifier = Modifier.padding(top = 2.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
 
 @Composable
 fun TabContent(selectedTabIndex: Int, navHostController: NavHostController) {
@@ -144,6 +106,52 @@ fun TabContent(selectedTabIndex: Int, navHostController: NavHostController) {
 @Composable
 fun AnalysisPreview() {
     SpenderTheme {
-        TabSelector(listOf("캘린더", "그래프"), 0, { })
+        val tabs = listOf("캘린더", "그래프")
+
+        TabRow(
+            selectedTabIndex = 0,
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .height(56.dp)
+                .clip(RoundedCornerShape(8.dp)),
+            containerColor = MaterialTheme.colorScheme.tertiary,
+            indicator = { tabPositions ->
+                Box(
+                    modifier = Modifier
+                        .tabIndicatorOffset(tabPositions[0])
+                        .fillMaxSize()
+                        .padding(4.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.background,
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                )
+            },
+            divider = {}
+        ) {
+            tabs.forEachIndexed { index, title ->
+                val isSelected = 0 == index
+                Box(
+                    modifier = Modifier
+                        .height(52.dp)
+                        .fillMaxHeight()
+                        .zIndex(1f)
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { }
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = title,
+                        style = Typography.titleMedium,
+                        color = if (isSelected) MaterialTheme.colorScheme.onBackground else MaterialTheme.colorScheme.onTertiary,
+                        modifier = Modifier.padding(horizontal = 16.dp)
+                    )
+                }
+            }
+        }
     }
 }

--- a/Spender/app/src/main/java/com/example/spender/feature/analysis/AnalysisScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/analysis/AnalysisScreen.kt
@@ -87,7 +87,7 @@ fun AnalysisScreen(navHostController: NavHostController) {
             }
         }
 
-        Spacer(modifier = Modifier.height(30.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         TabContent(selectedTabIndex, navHostController)
     }

--- a/Spender/app/src/main/java/com/example/spender/feature/analysis/ui/graph/Graph.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/analysis/ui/graph/Graph.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -34,7 +35,7 @@ fun LineChart(sampleData: List<CalendarItemData>) {
         val avg = graphData.sumOf { it.expense } / 31
 
         val data = mutableListOf<CalendarItemData>()
-        for (i in 1 .. 31) {
+        for (i in 1..31) {
             val graph = graphData.filter { it.day == i }
             if (graph.isNotEmpty()) {
                 data.add(graph.first())
@@ -43,7 +44,8 @@ fun LineChart(sampleData: List<CalendarItemData>) {
             data.add(CalendarItemData(i, 0))
         }
 
-        val dataSet = LineDataSet(data.map { Entry(it.day.toFloat(), it.expense.toFloat()) }.toList(), "지출")
+        val dataSet =
+            LineDataSet(data.map { Entry(it.day.toFloat(), it.expense.toFloat()) }.toList(), "지출")
         dataSet.apply {
             lineWidth = 2f
             color = PointColor.toArgb()
@@ -52,6 +54,8 @@ fun LineChart(sampleData: List<CalendarItemData>) {
             setDrawCircles(false)
             mode = LineDataSet.Mode.LINEAR
         }
+
+        val labelColor = MaterialTheme.colorScheme.onBackground.toArgb()
 
         AndroidView(
             modifier = Modifier
@@ -75,6 +79,7 @@ fun LineChart(sampleData: List<CalendarItemData>) {
                             }
                         }
                         setDrawGridLines(false)
+                        textColor = labelColor
                     }
                     axisLeft.apply {
                         setDrawGridLines(true)
@@ -85,6 +90,7 @@ fun LineChart(sampleData: List<CalendarItemData>) {
                                 else "${value.toInt() / 10000}만원"
                             }
                         }
+                        textColor = labelColor
                     }
                     axisRight.isEnabled = false
                 }

--- a/Spender/app/src/main/java/com/example/spender/feature/expense/ui/ExpenseContent.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/expense/ui/ExpenseContent.kt
@@ -275,7 +275,7 @@ fun ExpenseContent(
                 onValueChange = { viewModel.onMemoChange(it) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(240.dp),
+                    .height(120.dp),
                 placeholder = {
                     Text(
                         "메모",
@@ -339,13 +339,13 @@ fun EmotionTagGroup(
                 label = {
                     Text(
                         text = emotion.name,
-                        color = if (isSelected) Color.White else MaterialTheme.colorScheme.onPrimary
+                        color = if (isSelected) Color.White else MaterialTheme.colorScheme.onBackground
                     )
                 },
                 shape = RoundedCornerShape(30),
                 colors = FilterChipDefaults.filterChipColors(
                     containerColor = MaterialTheme.colorScheme.background,
-                    labelColor = MaterialTheme.colorScheme.onPrimary,
+                    labelColor = MaterialTheme.colorScheme.onBackground,
                     selectedContainerColor = PointColor,
                     selectedLabelColor = Color.White
                 ),

--- a/Spender/app/src/main/java/com/example/spender/feature/expense/ui/expensedetail/ExpenseDetailScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/expense/ui/expensedetail/ExpenseDetailScreen.kt
@@ -69,6 +69,7 @@ import com.example.spender.feature.expense.ui.RegistrationUiState
 import com.example.spender.feature.expense.ui.RegistrationViewModel
 import com.example.spender.feature.expense.ui.CategoryBottomSheetItem
 import com.example.spender.ui.theme.BlackColor
+import com.example.spender.ui.theme.LightPointColor
 import com.example.spender.ui.theme.PointColor
 import com.example.spender.ui.theme.Typography
 import com.example.spender.ui.theme.navigation.Screen
@@ -97,6 +98,7 @@ fun ExpenseDetailScreen(
                 is RegistrationEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }
+
                 is RegistrationEvent.NavigateBack -> {
                     navHostController.popBackStack()
                 }
@@ -199,15 +201,15 @@ fun ExpenseDetailScreen(
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 CustomShortButton(
-                    "삭제",
-                    MaterialTheme.colorScheme.secondary,
-                    onClick = {viewModel.deleteExpense()},
+                    text = "삭제",
+                    backgroundColor = LightPointColor,
+                    onClick = { viewModel.deleteExpense() },
                     modifier = Modifier.weight(1f)
                 )
                 CustomShortButton(
                     "수정",
                     PointColor,
-                    onClick = {viewModel.updateExpense()},
+                    onClick = { viewModel.updateExpense() },
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -230,7 +232,13 @@ fun ExpenseDetailScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 40.dp, vertical = 16.dp),
-                    placeholder = { Text("지출을 입력하세요", fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)) },
+                    placeholder = {
+                        Text(
+                            "지출을 입력하세요",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onTertiary
+                        )
+                    },
                     trailingIcon = { Text("원", fontSize = 16.sp, fontWeight = FontWeight.Bold) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     visualTransformation = NumberCommaTransformation(),
@@ -243,8 +251,8 @@ fun ExpenseDetailScreen(
                     colors = TextFieldDefaults.colors(
                         unfocusedContainerColor = Color.Transparent,
                         focusedContainerColor = Color.Transparent,
-                        unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                        focusedIndicatorColor = MaterialTheme.colorScheme.primary
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.tertiary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.tertiary
                     )
                 )
 
@@ -253,20 +261,25 @@ fun ExpenseDetailScreen(
                     value = uiState.title,
                     onValueChange = { viewModel.onTitleChange(it) },
                     modifier = Modifier.fillMaxWidth(),
-                    placeholder = { Text("지출 내용을 입력하세요", fontSize = 16.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)) },
+                    placeholder = {
+                        Text(
+                            "지출 내용을 입력하세요",
+                            fontSize = 16.sp,
+                            color = MaterialTheme.colorScheme.onTertiary
+                        )
+                    },
                     singleLine = true,
                     textStyle = TextStyle(fontSize = 18.sp),
                     colors = TextFieldDefaults.colors(
                         unfocusedContainerColor = Color.Transparent,
                         focusedContainerColor = Color.Transparent,
-                        unfocusedIndicatorColor = MaterialTheme.colorScheme.outline
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.tertiary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.tertiary
                     )
                 )
             }
 
-            Spacer(Modifier.height(12.dp))
-
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             // 카테고리
             Column(
@@ -294,7 +307,7 @@ fun ExpenseDetailScreen(
                     Spacer(Modifier.weight(1f))
                 }
             }
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             Column(
                 modifier = Modifier
@@ -327,7 +340,7 @@ fun ExpenseDetailScreen(
                     )
                 }
             }
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             // 감정 태그
             Column(modifier = Modifier.padding(horizontal = 34.dp, vertical = 24.dp)) {
@@ -343,7 +356,7 @@ fun ExpenseDetailScreen(
                 )
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             // 메모
             Column(modifier = Modifier.padding(horizontal = 34.dp, vertical = 24.dp)) {
@@ -354,25 +367,25 @@ fun ExpenseDetailScreen(
                 Spacer(Modifier.height(30.dp))
                 OutlinedTextField(
                     value = uiState.memo,
-                    onValueChange = {viewModel.onMemoChange(it)},
+                    onValueChange = { viewModel.onMemoChange(it) },
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(120.dp),
                     placeholder = {
                         Text(
                             "메모",
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            color = MaterialTheme.colorScheme.tertiary,
                             fontSize = 14.sp
                         )
                     },
                     textStyle = TextStyle(
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onTertiary,
+                        fontSize = 14.sp,
                     ),
                     shape = RoundedCornerShape(12.dp),
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = MaterialTheme.colorScheme.outline
+                        focusedBorderColor = MaterialTheme.colorScheme.tertiary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.tertiary
                     )
                 )
             }

--- a/Spender/app/src/main/java/com/example/spender/feature/expense/ui/recurringexpensedetail/RegularExpenseDetailScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/expense/ui/recurringexpensedetail/RegularExpenseDetailScreen.kt
@@ -18,16 +18,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.DateRange
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDefaults
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
@@ -37,7 +34,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -66,7 +62,7 @@ import com.example.spender.feature.expense.ui.NumberCommaTransformation
 import com.example.spender.feature.expense.ui.RegistrationEvent
 import com.example.spender.feature.expense.ui.RepeatDaySelectionSheet
 import com.example.spender.feature.expense.ui.CategoryBottomSheetItem
-import com.example.spender.ui.theme.BlackColor
+import com.example.spender.ui.theme.LightPointColor
 import com.example.spender.ui.theme.PointColor
 import com.example.spender.ui.theme.Typography
 import com.example.spender.ui.theme.navigation.Screen
@@ -95,6 +91,7 @@ fun RecurringExpenseDetailScreen(
                 is RegistrationEvent.ShowToast -> {
                     Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
                 }
+
                 is RegistrationEvent.NavigateBack -> {
                     navHostController.popBackStack()
                 }
@@ -218,14 +215,14 @@ fun RecurringExpenseDetailScreen(
             ) {
                 CustomShortButton(
                     "삭제",
-                    MaterialTheme.colorScheme.secondary,
-                    onClick = {viewModel.deleteRegularExpense()},
+                    backgroundColor = LightPointColor,
+                    onClick = { viewModel.deleteRegularExpense() },
                     modifier = Modifier.weight(1f)
                 )
                 CustomShortButton(
                     "수정",
                     PointColor,
-                    onClick = {viewModel.updateRegularExpense()},
+                    onClick = { viewModel.updateRegularExpense() },
                     modifier = Modifier.weight(1f)
                 )
             }
@@ -248,7 +245,13 @@ fun RecurringExpenseDetailScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 40.dp, vertical = 16.dp),
-                    placeholder = { Text("지출을 입력하세요", fontSize = 14.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)) },
+                    placeholder = {
+                        Text(
+                            "지출을 입력하세요",
+                            fontSize = 14.sp,
+                            color = MaterialTheme.colorScheme.onTertiary
+                        )
+                    },
                     trailingIcon = { Text("원", fontSize = 16.sp, fontWeight = FontWeight.Bold) },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
                     visualTransformation = NumberCommaTransformation(),
@@ -261,8 +264,8 @@ fun RecurringExpenseDetailScreen(
                     colors = TextFieldDefaults.colors(
                         unfocusedContainerColor = Color.Transparent,
                         focusedContainerColor = Color.Transparent,
-                        unfocusedIndicatorColor = MaterialTheme.colorScheme.primary,
-                        focusedIndicatorColor = MaterialTheme.colorScheme.primary
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.tertiary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.tertiary
                     )
                 )
                 // 내용 입력
@@ -272,17 +275,24 @@ fun RecurringExpenseDetailScreen(
                         viewModel.onTitleChange(it)
                     },
                     modifier = Modifier.fillMaxWidth(),
-                    placeholder = { Text("정기지출 내용을 입력하세요", fontSize = 16.sp, color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)) },
+                    placeholder = {
+                        Text(
+                            "정기지출 내용을 입력하세요",
+                            fontSize = 16.sp,
+                            color = MaterialTheme.colorScheme.onTertiary
+                        )
+                    },
                     singleLine = true,
                     textStyle = TextStyle(fontSize = 18.sp),
                     colors = TextFieldDefaults.colors(
                         unfocusedContainerColor = Color.Transparent,
                         focusedContainerColor = Color.Transparent,
-                        unfocusedIndicatorColor = MaterialTheme.colorScheme.outline
+                        unfocusedIndicatorColor = MaterialTheme.colorScheme.tertiary,
+                        focusedIndicatorColor = MaterialTheme.colorScheme.tertiary
                     )
                 )
             }
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             // 카테고리
             Column(
@@ -311,7 +321,7 @@ fun RecurringExpenseDetailScreen(
                 }
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             //시작 일
             Column(
@@ -346,7 +356,7 @@ fun RecurringExpenseDetailScreen(
                 }
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
             // 반복
             Column(
@@ -375,7 +385,7 @@ fun RecurringExpenseDetailScreen(
                 }
             }
 
-            HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f))
+            HorizontalDivider(color = MaterialTheme.colorScheme.tertiary)
 
 
             // 메모
@@ -387,25 +397,25 @@ fun RecurringExpenseDetailScreen(
                 Spacer(Modifier.height(30.dp))
                 OutlinedTextField(
                     value = uiState.memo,
-                    onValueChange = {viewModel.onMemoChange(it)},
+                    onValueChange = { viewModel.onMemoChange(it) },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(260.dp),
+                        .height(120.dp),
                     placeholder = {
                         Text(
                             "메모",
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                            color = MaterialTheme.colorScheme.tertiary,
                             fontSize = 14.sp
                         )
                     },
                     textStyle = TextStyle(
-                        color = MaterialTheme.colorScheme.onSurface,
-                        fontSize = 16.sp,
+                        color = MaterialTheme.colorScheme.onTertiary,
+                        fontSize = 14.sp,
                     ),
                     shape = RoundedCornerShape(12.dp),
                     colors = OutlinedTextFieldDefaults.colors(
-                        focusedBorderColor = MaterialTheme.colorScheme.primary,
-                        unfocusedBorderColor = MaterialTheme.colorScheme.outline
+                        focusedBorderColor = MaterialTheme.colorScheme.tertiary,
+                        unfocusedBorderColor = MaterialTheme.colorScheme.tertiary
                     )
                 )
             }

--- a/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/NotificationScreen.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/mypage/ui/NotificationScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -103,10 +104,10 @@ private fun NotificationSettingRow(
             colors = SwitchDefaults.colors(
                 uncheckedThumbColor = Color.White, // 오프 동그라미 색
                 uncheckedTrackColor = Color(0xFFD9D9D9), // 오프 배경 색
-                uncheckedBorderColor = Color.White,
+                uncheckedBorderColor = MaterialTheme.colorScheme.tertiary,
                 checkedThumbColor = Color.White,   // 온 동그라미 색
                 checkedTrackColor = PointColor,   // 온 배경
-                checkedBorderColor = Color.White,
+                checkedBorderColor = MaterialTheme.colorScheme.tertiary,
             ),
             modifier = Modifier.scale(1.2f),
             thumbContent = {

--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/EmotionBarChart.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/EmotionBarChart.kt
@@ -3,7 +3,9 @@ package com.example.spender.feature.report.ui.component
 import android.graphics.Canvas
 import android.graphics.RectF
 import android.view.ViewGroup
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.viewinterop.AndroidView
 import com.github.mikephil.charting.animation.ChartAnimator
 import com.github.mikephil.charting.charts.HorizontalBarChart
@@ -22,6 +24,8 @@ fun EmotionBarChart(
     values: List<Float>,
     colors: List<Int>
 ) {
+    val labelColor = MaterialTheme.colorScheme.onBackground.toArgb()
+
     AndroidView(factory = { context ->
         HorizontalBarChart(context).apply {
             layoutParams = ViewGroup.LayoutParams(
@@ -43,6 +47,11 @@ fun EmotionBarChart(
                 granularity = 1f
                 valueFormatter = IndexAxisValueFormatter(labels)
                 textSize = 14f
+                textColor = labelColor
+            }
+
+            axisRight.apply {
+                textColor = labelColor
             }
 
         }

--- a/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/ReportContent.kt
+++ b/Spender/app/src/main/java/com/example/spender/feature/report/ui/component/ReportContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavHostController
@@ -101,6 +102,8 @@ fun MonthlySpendingBarChart(
     labels: List<String>,
     onBarClick: (Int) -> Unit
 ) {
+    val labelColor = MaterialTheme.colorScheme.onBackground.toArgb()
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -132,7 +135,7 @@ fun MonthlySpendingBarChart(
                         setDrawGridLines(false)
                         granularity = 1f
                         valueFormatter = IndexAxisValueFormatter(labels)
-                        textColor = android.graphics.Color.BLACK
+                        textColor = labelColor
                     }
 
                     axisLeft.isEnabled = false


### PR DESCRIPTION
## 변경 내용 요약
- 통계화면의 탭을 우리 어플의 테마에 맞게(피그마) 수정하였습니다
- 통계화면/그래프의 xy축 라벨 색을 수정하였습니다
- 리포트화면 차트의 x축 라벨 색을 수정하였습니다
- 리포트 디테일화면 차트의 xy축 라벨 색을 수정하였습니다


## UI 스크릿샷 or 기능 테스트 방법
<img width="394" height="470" alt="image" src="https://github.com/user-attachments/assets/90156428-b27e-4e8d-98e9-f4024f0969a8" />
<img width="386" height="134" alt="image" src="https://github.com/user-attachments/assets/af92bba3-0adb-475e-a569-3d233b2d55dd" />
<img width="350" height="190" alt="image" src="https://github.com/user-attachments/assets/f933a739-3d63-40b9-9fac-1df8f0bfac52" />


## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
