### PR TITLE
[Fix] 지출/수입 내역 검색기능 로직변경 

### DIFF
--- a/Spender/app/src/main/java/com/e1i3/spender/feature/expense/data/repository/ExpenseRepository.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/expense/data/repository/ExpenseRepository.kt
@@ -21,7 +21,9 @@ class ExpenseRepository @Inject constructor() {
 
     suspend fun getExpenseById(userId: String, expenseId: String): Expense? {
         return try {
-            val document = usersCollection.document(userId).collection("expenses").document(expenseId).get().await()
+            val document =
+                usersCollection.document(userId).collection("expenses").document(expenseId).get()
+                    .await()
             document.toObject(Expense::class.java)?.copy(id = document.id)
         } catch (e: Exception) {
             null
@@ -30,28 +32,34 @@ class ExpenseRepository @Inject constructor() {
 
     suspend fun updateExpense(userId: String, expenseId: String, expenseDto: ExpenseDto): Boolean {
         return try {
-            usersCollection.document(userId).collection("expenses").document(expenseId).set(expenseDto).await()
+            usersCollection.document(userId).collection("expenses").document(expenseId)
+                .set(expenseDto).await()
             true
-        } catch (e: Exception) { false }
+        } catch (e: Exception) {
+            false
+        }
     }
 
     suspend fun deleteExpense(userId: String, expenseId: String): Boolean {
         return try {
-            usersCollection.document(userId).collection("expenses").document(expenseId).delete().await()
+            usersCollection.document(userId).collection("expenses").document(expenseId).delete()
+                .await()
             true
-        } catch (e: Exception) { false }
+        } catch (e: Exception) {
+            false
+        }
     }
 
     suspend fun searchExpenses(userId: String, query: String): List<Expense> {
         return try {
             val snapshot = usersCollection.document(userId).collection("expenses")
-                .whereGreaterThanOrEqualTo("title", query)
-                .whereLessThanOrEqualTo("title", query + "\uf8ff")
                 .get().await()
 
-            snapshot.documents.mapNotNull { document ->
+            val allExpenses = snapshot.documents.mapNotNull { document ->
                 document.toObject(Expense::class.java)?.copy(id = document.id)
             }
+
+            allExpenses.filter { it.title.contains(query, ignoreCase = true) }
         } catch (e: Exception) {
             emptyList()
         }

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/expensedetail/ExpenseDetailScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/expensedetail/ExpenseDetailScreen.kt
@@ -408,7 +408,7 @@ fun ExpenseDetailScreen(
                 )
                 Spacer(Modifier.height(16.dp))
 
-                if (uiState.imageUrl != null) {
+                if (!uiState.imageUrl.isNullOrBlank()) {
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/domain/model/Transaction.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/domain/model/Transaction.kt
@@ -1,8 +1,11 @@
 package com.e1i3.spender.feature.home.domain.model
 
+import java.util.Date
+
 data class Transaction(
     val id: String,
     val title: String,
     val amount: Long,
-    val type: String
+    val type: String,
+    val date: Date
 )

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/RecentTransactionSection.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/RecentTransactionSection.kt
@@ -44,6 +44,7 @@ fun RecentTransactionsSection(
                 title = expense.title,
                 amount = expense.amount,
                 type = "EXPENSE",
+                date = expense.date.toDate(),
                 onClick = {
                     navHostController.navigate(
                         Screen.ExpenseDetailScreen.createRoute(expense.id)

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/SearchScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/SearchScreen.kt
@@ -131,6 +131,7 @@ fun SearchScreen(
                         title = transaction.title,
                         amount = transaction.amount.toInt(),
                         type = transaction.type,
+                        date = transaction.date,
                         onClick = {
                             val route = if (transaction.type == "EXPENSE") {
                                 Screen.ExpenseDetailScreen.createRoute(transaction.id)

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/SearchScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/SearchScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.e1i3.spender.feature.home.ui.component.RecentItem
+import com.e1i3.spender.feature.home.ui.viewModel.SearchViewModel
 import com.e1i3.spender.ui.theme.Typography
 import com.e1i3.spender.ui.theme.navigation.Screen
 

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/SearchViewModel.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/SearchViewModel.kt
@@ -43,11 +43,11 @@ class SearchViewModel @Inject constructor(
 
             val results = if (_uiState.value.selectedTabIndex == 0) {
                 expenseRepository.searchExpenses(userId, query).map {
-                    Transaction(it.id, it.title, it.amount, "EXPENSE")
+                    Transaction(it.id, it.title, it.amount, "EXPENSE", it.date)
                 }
             } else {
                 incomeRepository.searchIncomes(userId, query).map {
-                    Transaction(it.id, it.title, it.amount, "INCOME")
+                    Transaction(it.id, it.title, it.amount, "INCOME", it.date)
                 }
             }
             _uiState.update { it.copy(searchResults = results) }

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/RecentItem.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/RecentItem.kt
@@ -2,10 +2,12 @@ package com.e1i3.spender.feature.home.ui.component
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -14,16 +16,22 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.e1i3.spender.core.common.util.toCurrency
 import com.e1i3.spender.ui.theme.PointColor
 import com.e1i3.spender.ui.theme.Typography
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 @Composable
 fun RecentItem(
     title: String,
     amount: Int,
     type: String,
+    date: Date,
     onClick: () -> Unit
 ) {
     Card(
@@ -43,6 +51,15 @@ fun RecentItem(
                 .padding(24.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            val dateFormat = SimpleDateFormat("MM.dd", Locale.getDefault())
+            Text(
+                text = dateFormat.format(date),
+                style = Typography.bodySmall,
+                fontSize = 12.sp,
+                color = Color.Gray
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+
             Text(
                 text = title,
                 style = Typography.bodyMedium,

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/RecentItem.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/RecentItem.kt
@@ -1,6 +1,8 @@
 package com.e1i3.spender.feature.home.ui.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -48,25 +50,24 @@ fun RecentItem(
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight()
-                .padding(24.dp),
+                .padding(18.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            val dateFormat = SimpleDateFormat("MM.dd", Locale.getDefault())
-            Text(
-                text = dateFormat.format(date),
-                style = Typography.bodySmall,
-                fontSize = 12.sp,
-                color = Color.Gray
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-
-            Text(
-                text = title,
-                style = Typography.bodyMedium,
-                modifier = Modifier.weight(1f),
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            Row {
+            Column(modifier = Modifier.weight(1f),) {
+                Text(
+                    text = title,
+                    style = Typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                val dateFormat = SimpleDateFormat("yy.MM.dd", Locale.getDefault())
+                Text(
+                    text = dateFormat.format(date),
+                    style = Typography.bodySmall,
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+            }
+            Row(verticalAlignment = Alignment.Bottom) {
                 val amountText = if (type == "INCOME") {
                     "+ ${amount.toCurrency()}"
                 } else {

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/viewModel/SearchViewModel.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/viewModel/SearchViewModel.kt
@@ -1,10 +1,11 @@
-package com.e1i3.spender.feature.home.ui
+package com.e1i3.spender.feature.home.ui.viewModel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.e1i3.spender.core.data.service.getFirebaseAuth
 import com.e1i3.spender.feature.expense.data.repository.ExpenseRepository
 import com.e1i3.spender.feature.home.domain.model.Transaction
+import com.e1i3.spender.feature.home.ui.SearchUiState
 import com.e1i3.spender.feature.income.data.repository.IncomeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -50,7 +51,9 @@ class SearchViewModel @Inject constructor(
                     Transaction(it.id, it.title, it.amount, "INCOME", it.date)
                 }
             }
-            _uiState.update { it.copy(searchResults = results) }
+
+            val sortedResults = results.sortedByDescending { it.date }
+            _uiState.update { it.copy(searchResults = sortedResults) }
         }
     }
 }

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/income/data/repository/IncomeRepository.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/income/data/repository/IncomeRepository.kt
@@ -52,16 +52,15 @@ class IncomeRepository @Inject constructor() {
     suspend fun searchIncomes(userId: String, query: String): List<Income> {
         return try {
             val snapshot = usersCollection.document(userId).collection("incomes")
-                .whereGreaterThanOrEqualTo("title", query)
-                .whereLessThanOrEqualTo("title", query + "\uf8ff")
                 .get().await()
 
-            snapshot.documents.mapNotNull { document ->
+            val allIncomes = snapshot.documents.mapNotNull { document ->
                 document.toObject(Income::class.java)?.copy(id = document.id)
             }
+
+            allIncomes.filter { it.title.contains(query, ignoreCase = true) }
         } catch (e: Exception) {
             emptyList()
         }
-
     }
 }


### PR DESCRIPTION
## 변경 내용 요약
- 기존 [검색어]로 시작하는 내역만 필터링 -> [검색어]가 포함된 내역 필터링
- 지출/수입 내역에 날짜 표시하도록 수정

## UI 스크릿샷 or 기능 테스트 방법
<img width="378" height="741" alt="image" src="https://github.com/user-attachments/assets/cd6b6023-3b61-4156-9b6f-c4800ec85e68" />


## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
