### PR TITLE
[Fix] 닉네임필드 줄바꿈 불허로 변경

### DIFF
--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/MypageScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/MypageScreen.kt
@@ -85,7 +85,7 @@ fun MypageScreen(
             .padding(vertical = 14.dp)
     ) {
         UserInfoSection(
-            userName = user.displayName,
+            userName = user.displayNickname,
             iconRes = user.providerIcon,
             navHostController = navHostController
         )

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/MyinfoDialogs.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/MyinfoDialogs.kt
@@ -70,7 +70,12 @@ fun EditNicknameDialog(
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     TextField(
                         value = nickName,
-                        onValueChange = { if (!isLoading) nickName = it },
+                        onValueChange = { input ->
+                            if (!isLoading) {
+                                val newNickname = input.replace("\n", "")
+                                nickName = newNickname
+                            }
+                        },
                         placeholder = {
                             Text(
                                 "닉네임을 입력해주세요",

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/onboarding/ui/NicknameInputField.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/onboarding/ui/NicknameInputField.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -19,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.e1i3.spender.R
@@ -40,8 +42,9 @@ fun NicknameInputField(
             TextField(
                 value = nickName,
                 onValueChange = { input ->
-                    if (input.length <= 20) {
-                        onNicknameChange(input)
+                    val newNickname = input.replace("\n", "")
+                    if (newNickname.length <= 20) {
+                        onNicknameChange(newNickname)
                     }
                 },
                 colors = TextFieldDefaults.colors(
@@ -59,7 +62,13 @@ fun NicknameInputField(
                         color = MaterialTheme.colorScheme.tertiary
                     )
                 },
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Text,
+                    imeAction = ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(
+                    onDone = null
+                ),
                 modifier = Modifier.weight(1f),
                 singleLine = true
             )

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/onboarding/ui/NicknameInputField.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/onboarding/ui/NicknameInputField.kt
@@ -60,7 +60,8 @@ fun NicknameInputField(
                     )
                 },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
-                modifier = Modifier.weight(1f)
+                modifier = Modifier.weight(1f),
+                singleLine = true
             )
         }
 


### PR DESCRIPTION
## 변경 내용 요약
- 온보딩 화면에서 닉네임 입력받을 때 줄바꿈 비허용으로 변경하였습니다
- 내정보 화면에서 닉네임 입력받을 때 줄바꿈 비허용으로 변경하였습니다
- 마이페이지의 인포섹션에 기존: 이름 -> 변경: 닉네임 으로 변경하였습니다. 

## UI 스크릿샷 or 기능 테스트 방법


## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
