### PR TITLE
[Feat] 리포트 생성시 티어 추가되고 보이도록 수정 

### DIFF
--- a/Spender/app/src/main/java/com/e1i3/spender/core/data/remote/report/ReportDetailDto.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/core/data/remote/report/ReportDetailDto.kt
@@ -3,6 +3,7 @@ package com.e1i3.spender.core.data.remote.report
 data class ReportDetailDto (
     val totalBudget: Int,
     val totalExpense: Int,
+    val tier: Int,
     val feedback: String = "",
     val month: String,
     val byCategory: List<CategoryTotalDto>,

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/report/domain/model/ReportDetail.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/report/domain/model/ReportDetail.kt
@@ -2,6 +2,7 @@ package com.e1i3.spender.feature.report.domain.model
 
 data class ReportDetail(
     val month: String,
+    val tier: Int,
     val totalExpense: Int,
     val totalBudget: Int,
     val feedback: String,

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/report/domain/repository/ReportRepository.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/report/domain/repository/ReportRepository.kt
@@ -32,7 +32,7 @@ class ReportRepository @Inject constructor(
                 ReportListDto(
                     month = doc.id,
                     totalExpense = (data["totalExpense"] as? Number)?.toInt() ?: 0,
-                    totalBudget  = (data["totalBudget"] as? Number)?.toInt() ?: 0
+                    totalBudget = (data["totalBudget"] as? Number)?.toInt() ?: 0
                 )
             } catch (e: Exception) {
                 null
@@ -55,26 +55,27 @@ class ReportRepository @Inject constructor(
         val data = documentSnapshot.data ?: error("데이터 없음")
 
         val byCategory = (data["byCategory"] as? List<Map<String, Any>>)?.mapNotNull {
-            val id    = it["categoryId"] as? String ?: return@mapNotNull null
-            val name  = it["categoryName"] as? String ?: return@mapNotNull null
+            val id = it["categoryId"] as? String ?: return@mapNotNull null
+            val name = it["categoryName"] as? String ?: return@mapNotNull null
             val price = (it["totalPrice"] as? Number)?.toInt() ?: 0
             val color = it["color"] as? String ?: return@mapNotNull null
             CategoryTotalDto(id, name, price, color)
         } ?: emptyList()
 
         val byEmotion = (data["byEmotion"] as? List<Map<String, Any>>)?.mapNotNull {
-            val id  = it["emotionId"] as? String ?: return@mapNotNull null
+            val id = it["emotionId"] as? String ?: return@mapNotNull null
             val amt = (it["amount"] as? Number)?.toInt() ?: 0
             EmotionTotalDto(id, amt)
         } ?: emptyList()
 
         ReportDetailDto(
-            month        = documentSnapshot.id,
-            totalBudget  = (data["totalBudget"] as? Number)?.toInt() ?: 0,
+            month = documentSnapshot.id,
+            tier = (data["tier"] as? Number)?.toInt() ?: 3,
+            totalBudget = (data["totalBudget"] as? Number)?.toInt() ?: 0,
             totalExpense = (data["totalExpense"] as? Number)?.toInt() ?: 0,
-            feedback     = data["feedback"] as? String ?: "",
-            byCategory   = byCategory,
-            byEmotion    = byEmotion,
+            feedback = data["feedback"] as? String ?: "",
+            byCategory = byCategory,
+            byEmotion = byEmotion,
         )
     }
 }

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/report/mapper/ReportMapper.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/report/mapper/ReportMapper.kt
@@ -24,6 +24,7 @@ object ReportMapper {
             month = dto.month,
             totalExpense = dto.totalExpense,
             totalBudget = dto.totalBudget,
+            tier = dto.tier,
             feedback = dto.feedback,
             byCategory = dto.byCategory.map {
                 CategoryTotal(

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/report/ui/component/ReportContent.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/report/ui/component/ReportContent.kt
@@ -75,7 +75,7 @@ fun ReportContent(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 16.dp)
-                .padding(top = 3.dp),
+                .padding(top = 7.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             itemsIndexed(reports) { index, report ->

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/report/ui/detail/ReportDetailScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/report/ui/detail/ReportDetailScreen.kt
@@ -1,6 +1,9 @@
 package com.e1i3.spender.feature.report.ui.detail
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
@@ -13,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import com.e1i3.spender.core.common.util.toYearMonth
 import com.e1i3.spender.core.ui.CustomTopAppBar
+import com.e1i3.spender.feature.home.ui.component.TierBadge
 import com.e1i3.spender.feature.report.mapper.toUiModel
 import com.e1i3.spender.feature.report.ui.component.BudgetProgressSection
 import com.e1i3.spender.feature.report.ui.component.CategorySpendingSection
@@ -46,8 +50,18 @@ fun ReportDetailScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(padding)
-                    .padding(horizontal = 24.dp, vertical = 24.dp)
+                    .padding(horizontal = 24.dp, vertical = 0.dp)
             ) {
+                // 티어
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 20.dp),
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        TierBadge(level = report.tier)
+                    }
+                }
+
                 // 이번달 총 지출
                 item {
                     TotalSpendingSection(totalExpense = report.totalExpense, totalBudget = report.totalBudget)

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/report/ui/detail/ReportDetailViewModel.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/report/ui/detail/ReportDetailViewModel.kt
@@ -22,6 +22,7 @@ class ReportDetailViewModel @Inject constructor(
     private val _reportDetail = mutableStateOf(
         ReportDetail(
             month = "",
+            tier = 3,
             totalExpense = 0,
             totalBudget = 0,
             feedback = "",

--- a/Spender/firebase/functions/report-generator.js
+++ b/Spender/firebase/functions/report-generator.js
@@ -191,8 +191,10 @@ const generateMonthlyReports = pubsub
         }
 
         const feedback = await generateFeedback(summary);
+
         await userRef.collection("reports").doc(monthStr).set({
           ...summary,
+          tier: newTier,
           feedback,
           month: monthStr,
           createdAt: admin.firestore.FieldValue.serverTimestamp(),


### PR DESCRIPTION
## 변경 내용 요약
- functions에서 매월 1일 리포트 저장할때 티어 정보도 저장되도록 수정했습니다!
- 리포트 상세 조회에서도 티어 정보를 화면에 띄우도록 수정했습니다! 

## UI 스크릿샷 or 기능 테스트 방법
<img width="540" height="1110" alt="Image" src="https://github.com/user-attachments/assets/312d46b1-10a8-4d9b-8c2f-bbe1509933bb" />

## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
