### PR TITLE
[Fix] 알림 설정 문구 수정 및 프로필 이미지에 그림자 및 외곽선 추가

### DIFF
--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/FirendItem.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/FirendItem.kt
@@ -3,10 +3,12 @@ package com.e1i3.spender.feature.home.ui.component
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -23,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
@@ -66,14 +69,24 @@ fun FriendItem(
                 placeholder = painterResource(id = R.drawable.spender_default)
             )
 
-            Image(
-                painter = painter,
-                contentDescription = "${friend.nickname}의 프로필",
+
+            Box(
                 modifier = Modifier
                     .size(60.dp)
-                    .clip(CircleShape),
-                contentScale = ContentScale.Crop
-            )
+                    .shadow(elevation = 2.dp, shape = CircleShape, clip = false)
+                    .background(MaterialTheme.colorScheme.surface, CircleShape)
+                    .padding(2.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painter,
+                    contentDescription = "${friend.nickname}의 프로필",
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape),
+                    contentScale = ContentScale.Crop
+                )
+            }
 
             Text(
                 modifier = Modifier.padding(top = 5.dp),

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/MypageScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/MypageScreen.kt
@@ -189,8 +189,7 @@ fun MypageScreen(
 fun AdMobBanner() {
     Box(
         modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 0.dp),
+            .fillMaxWidth(),
         contentAlignment = Alignment.Center
     ) {
         AndroidView(
@@ -216,7 +215,7 @@ fun UserInfoSection(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 10.dp, horizontal = 28.dp),
+            .padding(vertical = 5.dp, horizontal = 28.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         CircularImage(

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/NotificationScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/NotificationScreen.kt
@@ -20,9 +20,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
+import com.e1i3.spender.R
 import com.e1i3.spender.core.ui.CustomTopAppBar
 import com.e1i3.spender.feature.mypage.ui.viewmodel.NotificationSettingsViewModel
 import com.e1i3.spender.ui.theme.PointColor
@@ -56,21 +59,21 @@ fun NotificationScreen(
             ) {
                 item {
                     NotificationSettingRow(
-                        title = "지출 리포트 피드백 알림",
+                        title = stringResource(R.string.notification_setting_report),
                         checked = settings?.reportAlert ?: false,
                         onCheckedChange = { viewModel.toggleReport(it) }
                     )
                 }
                 item {
                     NotificationSettingRow(
-                        title = "정기 지출 예정 알림",
+                        title = stringResource(R.string.notification_setting_regular),
                         checked = settings?.reminderAlert ?: false,
                         onCheckedChange = { viewModel.toggleReminder(it) }
                     )
                 }
                 item {
                     NotificationSettingRow(
-                        title = "예산 초과/임박 알림",
+                        title = stringResource(R.string.notification_setting_budget),
                         checked = settings?.budgetAlert ?: false,
                         onCheckedChange = { viewModel.toggleBudget(it) }
                     )
@@ -94,7 +97,8 @@ private fun NotificationSettingRow(
     ) {
         Text(
             text = title,
-            style = Typography.titleMedium
+            style = Typography.titleSmall,
+            fontSize = 17.sp
         )
         Switch(
             checked = checked,

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/CircularImage.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/CircularImage.kt
@@ -1,16 +1,20 @@
 package com.e1i3.spender.feature.mypage.ui.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -30,7 +34,9 @@ fun CircularImage(
     Card(
         modifier = Modifier
             .size(size)
-            .clip(CircleShape),
+            .shadow(elevation = 3.dp, shape = CircleShape, clip = false)
+            .background(MaterialTheme.colorScheme.surface , CircleShape)
+            .border(width = 1.dp, color = MaterialTheme.colorScheme.outlineVariant, shape = CircleShape),
         colors = CardDefaults.cardColors(
             containerColor = WhiteColor
         )

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/MyPageItem.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/MyPageItem.kt
@@ -22,7 +22,7 @@ fun MyPageItem(item: MyPageItemType, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clickable { onClick() }
-            .padding(vertical = 11.dp),
+            .padding(vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(item.icon, contentDescription = item.title, modifier = Modifier.size(24.dp), tint = MaterialTheme.colorScheme.onBackground)

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/Section.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/mypage/ui/component/Section.kt
@@ -19,7 +19,7 @@ fun Section(
 ) {
     Column(modifier = Modifier.padding(horizontal = 30.dp).padding(top = 15.dp)) {
         Text(title, color = MaterialTheme.colorScheme.onTertiary, style = MaterialTheme.typography.titleSmall, fontSize = 16.sp)
-        Spacer(modifier = Modifier.height(3.dp))
+        Spacer(modifier = Modifier.height(2.dp))
         items.forEach { item ->
             MyPageItem(item = item, onClick = { onItemClick(item) })
         }

--- a/Spender/app/src/main/res/values/strings.xml
+++ b/Spender/app/src/main/res/values/strings.xml
@@ -20,4 +20,9 @@
     <string name="shortcut_expense_long">지출을 바로 등록합니다.</string>
     <string name="spender_small_widget_description">예산 대비 지출을 확입합니다.</string>
     <string name="spender_medium_widget_description">예산 대비 지출을 확인하고 지출을 바로 등록합니다.</string>
+
+    <string name="notification_setting_report">지출 리포트 피드백 알림</string>
+    <string name="notification_setting_regular">정기 지출 예정 알림</string>
+    <string name="notification_setting_budget">예산 중간 점검 알림</string>
+
 </resources>


### PR DESCRIPTION
## 변경 내용 요약
- 알림 설정 문구 수정했습니다! ( 예산 초과/임박 알림 → 예산 중간 점검 알림 ) 
- 프로필 이미지 뜨는 곳에 그림자 및 외곽선 추가했습니다! 

## UI 스크릿샷 or 기능 테스트 방법
<img width="540" height="1110" alt="Image" src="https://github.com/user-attachments/assets/ebd87812-07b7-4e73-9930-94f3a9be237d" />

<img width="540" height="1110" alt="Image" src="https://github.com/user-attachments/assets/981f27d4-afa2-40de-9293-311c1e3f5ae3" />

## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
