### PR TITLE
feature: 캘린더에 감정 태그 표시

### DIFF
--- a/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/domain/repository/CalendarRepository.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/domain/repository/CalendarRepository.kt
@@ -51,6 +51,7 @@ class CalendarRepository @Inject constructor(
                     memo = data["memo"]?.toString() ?: "",
                     title = data["title"]?.toString() ?: "",
                     date = data["date"] as? Timestamp ?: Timestamp.now(),
+                    emotionId = data["emotion"]?.toString() ?: "",
                     categoryId = data["categoryId"]?.toString() ?: "",
                     createdAt = data["createdAt"] as? Timestamp ?: Timestamp.now()
                 )
@@ -98,6 +99,7 @@ class CalendarRepository @Inject constructor(
                     memo = data["memo"]?.toString() ?: "",
                     title = data["title"]?.toString() ?: "",
                     date = data["date"] as? Timestamp ?: Timestamp.now(),
+                    emotionId = data["emotion"]?.toString() ?: "",
                     categoryId = data["categoryId"]?.toString() ?: "",
                     createdAt = data["createdAt"] as? Timestamp ?: Timestamp.now()
                 )
@@ -146,7 +148,7 @@ class CalendarRepository @Inject constructor(
                     title = data["title"]?.toString() ?: "",
                     date = data["date"] as? Timestamp ?: Timestamp.now(),
                     receiptUrl = "",
-                    emotionId = "",
+                    emotionId = data["emotion"]?.toString() ?: "",
                     categoryId = data["categoryId"]?.toString() ?: "",
                     createdAt = data["createdAt"] as? Timestamp ?: Timestamp.now()
                 )
@@ -170,7 +172,7 @@ class CalendarRepository @Inject constructor(
                     title = doc["title"]?.toString() ?: "",
                     date = doc["date"] as? Timestamp ?: Timestamp.now(),
                     receiptUrl = "",
-                    emotionId = "",
+                    emotionId = doc["emotion"]?.toString() ?: "",
                     categoryId = doc["categoryId"]?.toString() ?: "",
                     createdAt = doc["createdAt"] as? Timestamp ?: Timestamp.now()
                 )

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/mapper/EmotionMapper.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/mapper/EmotionMapper.kt
@@ -1,0 +1,11 @@
+package com.e1i3.spender.feature.analysis.mapper
+
+fun emotionIdToString(id: String): String {
+    return when(id) {
+        "satisfied" -> "#만족"
+        "dissatisfied" -> "#불만"
+        "impulsive" -> "#충동"
+        "unfair" -> "#억울"
+        else -> ""
+    }
+}

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/ui/SpendListItemComponent.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/ui/SpendListItemComponent.kt
@@ -1,6 +1,7 @@
 package com.e1i3.spender.feature.analysis.ui
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,15 +15,24 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.e1i3.spender.core.common.util.toCurrency
 import com.e1i3.spender.core.data.remote.expense.ExpenseDto
+import com.e1i3.spender.feature.analysis.mapper.emotionIdToString
 import com.e1i3.spender.ui.theme.PointColor
 import com.e1i3.spender.ui.theme.PointRedColor
 import com.e1i3.spender.ui.theme.Typography
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Locale
+import kotlin.math.abs
 
 @Composable
 fun SpendListItemComponent(item: ExpenseDto?, onClick: () -> Unit) {
+    val emotion = emotionIdToString(item?.emotionId ?: "")
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -37,18 +47,28 @@ fun SpendListItemComponent(item: ExpenseDto?, onClick: () -> Unit) {
             modifier = Modifier
                 .fillMaxWidth()
                 .fillMaxHeight()
-                .padding(24.dp),
+                .padding(horizontal = 24.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(
-                text = item?.title ?: "",
-                style = Typography.bodyMedium,
-                modifier = Modifier.weight(1f)
-            )
-            Row {
-                if ((item?.amount?.toInt() ?: 0) < 0) {
+            Column(modifier = Modifier.weight(1f),) {
+                Text(
+                    text = item?.title ?: "",
+                    style = Typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                if (emotion.isNotEmpty()) {
                     Text(
-                        text = "- ${Math.abs(item?.amount ?: 0).toCurrency()}",
+                        text = emotionIdToString(item?.emotionId ?: ""),
+                        style = Typography.bodySmall,
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+            Row {
+                if ((item?.amount ?: 0) < 0) {
+                    Text(
+                        text = "- ${abs(item?.amount ?: 0).toCurrency()}",
                         style = Typography.titleSmall.copy(
                             color = PointRedColor
                         )

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/ui/calendar/SpendListByDate.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/analysis/ui/calendar/SpendListByDate.kt
@@ -47,7 +47,7 @@ fun SpendListByDate(month: Int, day: Int, dayOfWeek: Int, list: List<ExpenseDto>
         Spacer(Modifier.height(10.dp))
         LazyColumn {
             itemsIndexed(list) { _, item ->
-                SpendListItemComponent(item, {
+                SpendListItemComponent(item) {
                     if (item.amount > 0) {
                         navHostController.navigate(
                             Screen.IncomeDetailScreen.createRoute(item.id)
@@ -57,7 +57,7 @@ fun SpendListByDate(month: Int, day: Int, dayOfWeek: Int, list: List<ExpenseDto>
                             Screen.ExpenseDetailScreen.createRoute(item.id)
                         )
                     }
-                })
+                }
                 Spacer(Modifier.height(8.dp))
             }
         }

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/RecentItem.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/home/ui/component/RecentItem.kt
@@ -64,7 +64,7 @@ fun RecentItem(
                     text = dateFormat.format(date),
                     style = Typography.bodySmall,
                     fontSize = 12.sp,
-                    color = Color.Gray
+                    color = MaterialTheme.colorScheme.onTertiary
                 )
             }
             Row(verticalAlignment = Alignment.Bottom) {


### PR DESCRIPTION
## 변경 내용 요약
- 캘린더 감정 태그 표시 기능 업데이트

## UI 스크릿샷 or 기능 테스트 방법
<img width="1080" height="2160" alt="image" src="https://github.com/user-attachments/assets/7655341f-92a3-4707-b6a3-908d1ee096b8" />


## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
