### PR TITLE
[Fix] 필드입력 후 다른 화면 클릭 시 키보드 포커스해제

### DIFF
--- a/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/ExpenseRegistrationParentScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/ExpenseRegistrationParentScreen.kt
@@ -3,6 +3,7 @@ package com.e1i3.spender.feature.expense.ui
 import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -29,7 +30,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -51,6 +54,7 @@ fun ExpenseRegistrationParentScreen(
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
     val tabs = listOf("지출", "정기지출")
+    val focusManager = LocalFocusManager.current
 //    val tabs = listOf("영수증", "지출", "정기지출") ocr아웃
 
     LaunchedEffect(key1 = initialTabIndex) {
@@ -122,6 +126,11 @@ fun ExpenseRegistrationParentScreen(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
         ) {
             // 탭 메뉴
             TabRow(

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/expensedetail/ExpenseDetailScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/expensedetail/ExpenseDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -61,7 +62,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -102,6 +105,7 @@ fun ExpenseDetailScreen(
     val datePickerState = rememberDatePickerState()
     val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(key1 = true) {
         viewModel.eventFlow.collect { event ->
@@ -239,6 +243,11 @@ fun ExpenseDetailScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
         ) {
             Column(modifier = Modifier.padding(horizontal = 20.dp)) {
 

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/ocrresult/OcrResultScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/ocrresult/OcrResultScreen.kt
@@ -2,6 +2,7 @@ package com.e1i3.spender.feature.expense.ui.ocrresult
 
 import android.widget.Toast
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -50,7 +51,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -89,6 +92,7 @@ fun OcrResultScreen(
     val scope = rememberCoroutineScope()
     val expenseCategories by viewModel.expenseCategories.collectAsState()
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(key1 = true) {
         viewModel.eventFlow.collect { event ->
@@ -211,6 +215,11 @@ fun OcrResultScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
         ) {
             //상단 안내 문구
             Column(

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/recurringexpensedetail/RegularExpenseDetailScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/expense/ui/recurringexpensedetail/RegularExpenseDetailScreen.kt
@@ -2,6 +2,7 @@ package com.e1i3.spender.feature.expense.ui.recurringexpensedetail
 
 import android.widget.Toast
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,7 +50,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -87,6 +90,7 @@ fun RecurringExpenseDetailScreen(
     val datePickerState = rememberDatePickerState()
     val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(key1 = true) {
         viewModel.eventFlow.collect { event ->
@@ -238,6 +242,11 @@ fun RecurringExpenseDetailScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
         ) {
             Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                 //지출 내용

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/income/ui/IncomeRegistrationScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/income/ui/IncomeRegistrationScreen.kt
@@ -2,6 +2,7 @@ package com.e1i3.spender.feature.income.ui
 
 import android.widget.Toast
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -51,7 +52,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -86,6 +89,7 @@ fun IncomeRegistrationScreen(
     var isSheetOpen by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(key1 = true) {
         viewModel.eventFlow.collect { event ->
@@ -215,6 +219,11 @@ fun IncomeRegistrationScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
         ) {
             Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                 //수입 내용

--- a/Spender/app/src/main/java/com/e1i3/spender/feature/income/ui/incomedetail/IncomeDetailScreen.kt
+++ b/Spender/app/src/main/java/com/e1i3/spender/feature/income/ui/incomedetail/IncomeDetailScreen.kt
@@ -2,6 +2,7 @@ package com.e1i3.spender.feature.income.ui.incomedetail
 
 import android.widget.Toast
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,7 +50,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -85,6 +88,7 @@ fun IncomeDetailScreen(
     val datePickerState = rememberDatePickerState()
     val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(key1 = true) {
         viewModel.eventFlow.collect { event ->
@@ -215,6 +219,11 @@ fun IncomeDetailScreen(
                 .padding(innerPadding)
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
+                .pointerInput(Unit) {
+                    detectTapGestures(onTap = {
+                        focusManager.clearFocus()
+                    })
+                },
         ){
             Column(modifier = Modifier.padding(horizontal = 20.dp)) {
                 //수입 내용


### PR DESCRIPTION
## 변경 내용 요약
- 기존 필드입력 후 키보드 내리기 버튼과 완료 버튼을 눌러야 키보드가 내려감 -> 다른곳을 탭하면 포커스가 해제되며 키보드가 내려감
- 

## UI 스크릿샷 or 기능 테스트 방법


## 체크 리스트
- [x] 기능 정상 동작 확인
- [x] 사이드 이펙트 확인
